### PR TITLE
Add React-based D&D sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# D&D Character Sheet Manager
+
+A simple React-based character sheet for Dungeons & Dragons. It uses Tailwind CSS for styling and stores data in your browser's local storage.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the development server:
+
+```bash
+npm start
+```
+
+Open `http://localhost:5173` in your browser.
+
+## Build
+
+To create a production build:
+
+```bash
+npm run build
+```

--- a/index.html
+++ b/index.html
@@ -1,1 +1,12 @@
-this is the index
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>D&D Character Sheet</title>
+  </head>
+  <body class="bg-white text-black dark:bg-black dark:text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dndsheet",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.5",
+    "vite": "^4.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import AbilityScores from './pages/AbilityScores';
+import Skills from './pages/Skills';
+import Spells from './pages/Spells';
+import Inventory from './pages/Inventory';
+
+const tabs = [
+  { id: 'abilities', label: 'Ability Scores' },
+  { id: 'skills', label: 'Skills & Saves' },
+  { id: 'spells', label: 'Spells' },
+  { id: 'inventory', label: 'Inventory' },
+];
+
+export default function App() {
+  const [tab, setTab] = useState('abilities');
+
+  const renderTab = () => {
+    switch (tab) {
+      case 'skills':
+        return <Skills />;
+      case 'spells':
+        return <Spells />;
+      case 'inventory':
+        return <Inventory />;
+      case 'abilities':
+      default:
+        return <AbilityScores />;
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex">
+      <nav className="w-40 bg-gray-100 dark:bg-gray-900 p-4">
+        <ul className="space-y-2">
+          {tabs.map((t) => (
+            <li key={t.id}>
+              <button
+                onClick={() => setTab(t.id)}
+                className={`w-full text-left py-2 px-3 rounded ${
+                  tab === t.id ? 'bg-gray-300 dark:bg-gray-700' : ''
+                }`}
+              >
+                {t.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <main className="flex-1 p-4">{renderTab()}</main>
+    </div>
+  );
+}

--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { rollDice } from '../utils/dnd';
+
+export default function DiceRoller({ formula = '', label = 'Roll' }) {
+  const [expr, setExpr] = useState(formula);
+  const [result, setResult] = useState(null);
+
+  const handleRoll = () => {
+    const res = rollDice(expr);
+    setResult(res);
+  };
+
+  return (
+    <div className="my-1">
+      {!formula && (
+        <input
+          className="border p-1 w-32 mr-2 dark:bg-gray-800"
+          value={expr}
+          onChange={(e) => setExpr(e.target.value)}
+          placeholder="2d6+3"
+        />
+      )}
+      <button
+        onClick={handleRoll}
+        className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+      >
+        {label}
+      </button>
+      {result && (
+        <div className="mt-1 text-sm">
+          <span className="mr-2">Rolls: {result.detail.join(' + ')}</span>
+          <span>Total: {result.total}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+export default function useLocalStorage(key, initialValue) {
+  const [value, setValue] = useState(() => {
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : initialValue;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/AbilityScores.jsx
+++ b/src/pages/AbilityScores.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import useLocalStorage from '../hooks/useLocalStorage';
+import DiceRoller from '../components/DiceRoller';
+import { abilityModifier } from '../utils/dnd';
+
+const abilities = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
+
+export default function AbilityScores() {
+  const [scores, setScores] = useLocalStorage('abilityScores', {
+    STR: 10,
+    DEX: 10,
+    CON: 10,
+    INT: 10,
+    WIS: 10,
+    CHA: 10,
+  });
+
+  const updateScore = (ability, val) => {
+    setScores({ ...scores, [ability]: parseInt(val, 10) || 0 });
+  };
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Ability Scores</h1>
+      <table className="min-w-full text-center">
+        <thead>
+          <tr className="border-b">
+            <th>Ability</th>
+            <th>Score</th>
+            <th>Modifier</th>
+            <th>Roll</th>
+          </tr>
+        </thead>
+        <tbody>
+          {abilities.map((ab) => (
+            <tr key={ab} className="border-b">
+              <td className="p-2 font-semibold">{ab}</td>
+              <td>
+                <input
+                  type="number"
+                  className="w-20 text-center"
+                  value={scores[ab]}
+                  onChange={(e) => updateScore(ab, e.target.value)}
+                />
+              </td>
+              <td>{abilityModifier(scores[ab]) >= 0 ? '+' : ''}{abilityModifier(scores[ab])}</td>
+              <td>
+                <DiceRoller formula={`1d20+${abilityModifier(scores[ab])}`} label="Roll" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-4">
+        <h2 className="font-semibold mb-2">Custom Roll</h2>
+        <DiceRoller />
+        <p className="text-sm text-gray-600 dark:text-gray-400">Use format like "2d6+3" or "4d6dl1" (drop lowest).</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Inventory.jsx
+++ b/src/pages/Inventory.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import useLocalStorage from '../hooks/useLocalStorage';
+
+export default function Inventory() {
+  const [items, setItems] = useLocalStorage('inventory', []);
+  const [scores] = useLocalStorage('abilityScores', {
+    STR: 10,
+    DEX: 10,
+    CON: 10,
+    INT: 10,
+    WIS: 10,
+    CHA: 10,
+  });
+  const weightLimit = scores.STR * 15;
+
+  const addItem = () => {
+    setItems([...items, { name: '', qty: 1, weight: 0, desc: '' }]);
+  };
+
+  const updateItem = (index, field, value) => {
+    const updated = [...items];
+    updated[index][field] = field === 'qty' || field === 'weight' ? parseFloat(value) || 0 : value;
+    setItems(updated);
+  };
+
+  const removeItem = (index) => {
+    const updated = [...items];
+    updated.splice(index, 1);
+    setItems(updated);
+  };
+
+  const totalWeight = items.reduce((sum, it) => sum + it.qty * it.weight, 0);
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Equipment & Inventory</h1>
+      <button
+        onClick={addItem}
+        className="mb-2 px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+      >
+        Add Item
+      </button>
+      <table className="min-w-full text-center">
+        <thead>
+          <tr className="border-b">
+            <th>Name</th>
+            <th>Qty</th>
+            <th>Weight</th>
+            <th>Description</th>
+            <th>Remove</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it, idx) => (
+            <tr key={idx} className="border-b">
+              <td className="p-1">
+                <input
+                  className="border p-1 dark:bg-gray-800"
+                  value={it.name}
+                  onChange={(e) => updateItem(idx, 'name', e.target.value)}
+                />
+              </td>
+              <td className="p-1 w-16">
+                <input
+                  type="number"
+                  className="border p-1 w-full dark:bg-gray-800"
+                  value={it.qty}
+                  onChange={(e) => updateItem(idx, 'qty', e.target.value)}
+                />
+              </td>
+              <td className="p-1 w-20">
+                <input
+                  type="number"
+                  className="border p-1 w-full dark:bg-gray-800"
+                  value={it.weight}
+                  onChange={(e) => updateItem(idx, 'weight', e.target.value)}
+                />
+              </td>
+              <td className="p-1">
+                <input
+                  className="border p-1 dark:bg-gray-800 w-full"
+                  value={it.desc}
+                  onChange={(e) => updateItem(idx, 'desc', e.target.value)}
+                />
+              </td>
+              <td className="p-1">
+                <button
+                  onClick={() => removeItem(idx)}
+                  className="px-2 py-1 bg-red-200 dark:bg-red-700 rounded"
+                >
+                  X
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-4">
+        <p>Total Weight: {totalWeight} / {weightLimit}</p>
+        {totalWeight > weightLimit && (
+          <p className="text-red-600">Encumbered!</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Skills.jsx
+++ b/src/pages/Skills.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import DiceRoller from '../components/DiceRoller';
+import useLocalStorage from '../hooks/useLocalStorage';
+import { abilityModifier } from '../utils/dnd';
+
+const skills = [
+  { name: 'Acrobatics', ability: 'DEX' },
+  { name: 'Animal Handling', ability: 'WIS' },
+  { name: 'Arcana', ability: 'INT' },
+  { name: 'Athletics', ability: 'STR' },
+  { name: 'Deception', ability: 'CHA' },
+  { name: 'History', ability: 'INT' },
+  { name: 'Insight', ability: 'WIS' },
+  { name: 'Intimidation', ability: 'CHA' },
+  { name: 'Investigation', ability: 'INT' },
+  { name: 'Medicine', ability: 'WIS' },
+  { name: 'Nature', ability: 'INT' },
+  { name: 'Perception', ability: 'WIS' },
+  { name: 'Performance', ability: 'CHA' },
+  { name: 'Persuasion', ability: 'CHA' },
+  { name: 'Religion', ability: 'INT' },
+  { name: 'Sleight of Hand', ability: 'DEX' },
+  { name: 'Stealth', ability: 'DEX' },
+  { name: 'Survival', ability: 'WIS' },
+];
+
+export default function Skills() {
+  const [scores] = useLocalStorage('abilityScores', {
+    STR: 10,
+    DEX: 10,
+    CON: 10,
+    INT: 10,
+    WIS: 10,
+    CHA: 10,
+  });
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Skills & Saves</h1>
+      <h2 className="font-semibold mt-4 mb-2">Saving Throws</h2>
+      <table className="mb-4 text-center">
+        <tbody>
+          {Object.keys(scores).map((ab) => (
+            <tr key={ab} className="border-b">
+              <td className="p-2 font-semibold">{ab} Save</td>
+              <td className="p-2">{abilityModifier(scores[ab]) >= 0 ? '+' : ''}{abilityModifier(scores[ab])}</td>
+              <td className="p-2">
+                <DiceRoller formula={`1d20+${abilityModifier(scores[ab])}`} label="Roll" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 className="font-semibold mt-4 mb-2">Skills</h2>
+      <table className="min-w-full text-center">
+        <thead>
+          <tr className="border-b">
+            <th>Skill</th>
+            <th>Modifier</th>
+            <th>Roll</th>
+          </tr>
+        </thead>
+        <tbody>
+          {skills.map((sk) => (
+            <tr key={sk.name} className="border-b">
+              <td className="p-2">{sk.name}</td>
+              <td className="p-2">{abilityModifier(scores[sk.ability]) >= 0 ? '+' : ''}{abilityModifier(scores[sk.ability])}</td>
+              <td className="p-2">
+                <DiceRoller formula={`1d20+${abilityModifier(scores[sk.ability])}`} label="Roll" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/Spells.jsx
+++ b/src/pages/Spells.jsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import useLocalStorage from '../hooks/useLocalStorage';
+
+export default function Spells() {
+  const [spells, setSpells] = useLocalStorage('spells', []);
+  const [newSpell, setNewSpell] = useState('');
+  const [slots, setSlots] = useLocalStorage('spellSlots', {
+    1: 0,
+    2: 0,
+    3: 0,
+    4: 0,
+    5: 0,
+    6: 0,
+    7: 0,
+    8: 0,
+    9: 0,
+  });
+
+  const addSpell = () => {
+    if (!newSpell) return;
+    setSpells([...spells, { name: newSpell, prepared: false }]);
+    setNewSpell('');
+  };
+
+  const togglePrepared = (index) => {
+    const updated = [...spells];
+    updated[index].prepared = !updated[index].prepared;
+    setSpells(updated);
+  };
+
+  const updateSlot = (level, value) => {
+    setSlots({ ...slots, [level]: parseInt(value, 10) || 0 });
+  };
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Spells</h1>
+
+      <h2 className="font-semibold mb-2">Spell Slots</h2>
+      <table className="mb-4 text-center">
+        <thead>
+          <tr className="border-b">
+            <th>Level</th>
+            <th>Slots</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.keys(slots).map((lvl) => (
+            <tr key={lvl} className="border-b">
+              <td className="p-2">{lvl}</td>
+              <td className="p-2">
+                <input
+                  type="number"
+                  className="w-20 text-center"
+                  value={slots[lvl]}
+                  onChange={(e) => updateSlot(lvl, e.target.value)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 className="font-semibold mb-2">Prepared Spells</h2>
+      <div className="mb-2">
+        <input
+          className="border p-1 mr-2 dark:bg-gray-800"
+          value={newSpell}
+          onChange={(e) => setNewSpell(e.target.value)}
+          placeholder="Spell name"
+        />
+        <button
+          onClick={addSpell}
+          className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+        >
+          Add Spell
+        </button>
+      </div>
+      <ul className="list-disc pl-6">
+        {spells.map((sp, idx) => (
+          <li key={idx} className="mb-1">
+            <label>
+              <input
+                type="checkbox"
+                className="mr-2"
+                checked={sp.prepared}
+                onChange={() => togglePrepared(idx)}
+              />
+              {sp.name}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/utils/dnd.js
+++ b/src/utils/dnd.js
@@ -1,0 +1,59 @@
+export function abilityModifier(score) {
+  return Math.floor((Number(score) - 10) / 2);
+}
+
+export function rollDice(formula) {
+  const clean = formula.replace(/\s+/g, '').toLowerCase();
+  const groups = clean.match(/[+-]?[^+-]+/g);
+  if (!groups) return { total: 0, detail: [] };
+
+  let total = 0;
+  const detail = [];
+
+  for (const group of groups) {
+    let sign = 1;
+    let part = group;
+    if (part[0] === '+') part = part.slice(1);
+    else if (part[0] === '-') { sign = -1; part = part.slice(1); }
+
+    const dlMatch = part.match(/(\d*)d(\d+)dl(\d+)?/); // drop lowest
+    if (dlMatch) {
+      const count = parseInt(dlMatch[1] || '1', 10);
+      const sides = parseInt(dlMatch[2], 10);
+      const drop = parseInt(dlMatch[3] || '1', 10);
+      const rolls = [];
+      for (let i = 0; i < count; i++) {
+        rolls.push(Math.ceil(Math.random() * sides));
+      }
+      const kept = [...rolls].sort((a,b) => a-b).slice(drop);
+      const sum = kept.reduce((a,b) => a+b, 0) * sign;
+      total += sum;
+      detail.push(`${sign < 0 ? '-' : ''}[${rolls.join(',')}] drop ${drop}`);
+      continue;
+    }
+
+    const match = part.match(/(\d*)d(\d+)/);
+    if (match) {
+      const count = parseInt(match[1] || '1', 10);
+      const sides = parseInt(match[2], 10);
+      let subtotal = 0;
+      const rolls = [];
+      for (let i = 0; i < count; i++) {
+        const r = Math.ceil(Math.random() * sides);
+        rolls.push(r);
+        subtotal += r;
+      }
+      total += sign * subtotal;
+      detail.push(`${sign < 0 ? '-' : ''}[${rolls.join(',')}]`);
+      continue;
+    }
+
+    const num = parseInt(part);
+    if (!isNaN(num)) {
+      total += sign * num;
+      detail.push(`${sign < 0 ? '-' : ''}${num}`);
+    }
+  }
+
+  return { total, detail };
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- initialize Vite React project
- configure Tailwind and PostCSS
- implement pages for ability scores, skills & saves, spells, and inventory
- add dice roller utilities and local storage hook
- provide README with setup instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684639c9625083329a5aadde4358a849